### PR TITLE
Xenomorph Maturity

### DIFF
--- a/xeno/maturity.md
+++ b/xeno/maturity.md
@@ -1,0 +1,121 @@
+## Abstract
+Maturity is a system that allows Xenomorphs to become stronger over the course of the round. As the round progresses
+Xenomorphs acquire new tiers they can "upgrade" into within their own caste, Each tier makes them either deal more damage,
+more tanky or able to build faster all depending on the caste. These upgrades are not free however, Each and every Xeno has
+to complete certain tasks depending on its caste in order to qualify for the upgrade, this is meant to reward players for playing
+well.
+
+## Goals
+- Reward players for playing well
+- Give xenomorphs a more scaling role
+	- Prevent endless FOB sieges
+	- Take away some of Boiler's strength
+- Give more meaning and difference to pushing \ defending
+	- Reward marines better for killing T3s or Primordial xenos as they can't be replaced as easily
+
+## Non-goals
+- Encourage AFKing. These upgrades are not free and should not be achiveable by simply AFKing in hive.
+- Make xenos too weak or too strong. Xenos should not be too weak while Young or unkillable while Primordial.
+- Discourage capping. Castes that are tasked with slashing should not be discouraged from capping but rather rewarded for that as well.
+
+## Content
+Maturity introduces 5 tiers of upgrades: Young, Mature, Elder, Ancient and Primordial. What each tier gives varies based on the caste.
+What is required to progress on each castes varies as well.
+
+- General notes
+	- All castes gain a large bit of upgrade progress from capturing marines, This is to prevent them for not capping ever because
+	their task is to deal damage.
+	- All castes except Runners, Lurkers and Ravagers gain some max health when upgrading.
+	- The amount of points for upgrading scales with the tier of the upgrade as well as the tier of the xenomorph, So acquiring
+	  a Primordial upgrade on a Crusher is much harder than it is on a defender.
+	- In addition to the tasks required to upgrade there is a time constraint: Xenomorphs start as Young in the beginning of the round
+	and have the Mature tier unlocked. Then, After every 30 minutes a new tier is unlocked for xenos to upgrade into. (So at 1:30 round time
+	xenos will have all tiers unlocked)
+	- You may gain upgrade progress for the next tier even if it's not unlocked yet however you may not gain an "overflow" for the tier
+	after that. (Similar to evolution)
+	- You gain 0 upgrade points passively, The system is meant to reward you for playing well, not for AFKing in hive.
+
+### Runners, Lurkers and Ravagers
+
+#### Upgrades
+"Ambush" or "Burst Damage" is the class of these castes, Therefore they get increased damage and speed. This is to make them better at
+their job without taking away their weakness, that being a small health pool or temporary shields holding them together in the frontline.
+
+#### Tasks
+Simply enough and matching with their role Runners, Lurker and Ravagers have to deal damage in order to gain upgrades.
+
+
+### Drones, Hivelords, Carriers and Burrowers
+
+#### Upgrades
+Builders and trappers, as they upgrade they gain increased plasma pools, increased plasma regeneration and increased armor
+and slash damage in the case of burrowers as they take a more offensive role.
+
+#### Tasks
+Drones and Hivelords gain upgrade points for builindg walls and doors and when doors and walls they build are destroyed by
+marines (Drones that cannot build gain points depending on their strain, Healer gains points for healing etc.)
+Carriers and Burrowers gain points whenever they build traps and when the traps are triggered, Carrier gains more points
+than other castes for capping.
+
+
+### Sentinels, Spitters and Boilers
+
+#### Upgrades
+As a whole the "ranged" class gain reduced cooldowns and increased damage. More specifically Spitters and Boilers 
+deal acid damage when slashing in their latter upgrades.
+
+#### Tasks
+Spitters and Boilers gain upgrade points for dealing acid\burn damage while spitters gain points for stunning or knocking
+down marines.
+
+
+### Defenders, Warriors and Crushers
+
+#### Upgrades
+The frontline class gains well, Increased frontlining capabilities. This means a balance between health, armor and slash damage.
+
+#### Tasks
+As this is a more general role they can get upgrade points from almost anything: Tanking damage, Stunning \ Knocking down marines
+or slashing and dleaing damage, However because of the plentiful ways for them to gain points they get a relatively reduced amount
+of points from these tasks.
+
+
+### Praetorians
+
+#### Upgrades & Tasks
+Praetorians are a bit of a wild card because of the wide array of roles they can take, Their upgrades depend on their strain:
+- Base and Warden: Same as ranged
+- Vanguard and Oppressor: Same as frontline
+- Dancer: Same as ambush
+
+
+### Queen
+
+#### Upgrades & Tasks
+The Queen is another wildcard, As they are a combination of pretty much every role they gain upgrade points from anything:
+Slashing, Capping, Taking damage, Building, Healing, Transfering Plasma etc..
+By the same logic they also gain increased all around stats with the exception of speed.
+The Queen's upgrade point requirement is the largest of all xenos, This is both because the Queen is the strongests Xenomorph and to reward Marines
+for taking her down.
+
+
+### Abomination \ Predalien
+
+#### Upgrades & Tasks
+Abominations are not affected by the Maturity system as they already have a scaling mechanic related to kills.
+
+
+## Alternatives
+- Keep the game as is resulting in:
+	- Endless FOB seiges
+	- No satisfaction in killing T3s as a new one just evolves
+
+## Potential Changes
+- "Xenomorphs get too strong too quickly"
+	- Make the amount of upgrade points required larger.
+- "X caste is unkillable when Primordial"
+	- Nerf its bonuses or switch them around.
+- "X caste is way too weak early on"
+	- Buff it at young and take some power from the later evolutions.
+- "Frontline castes are just slashing everyone without capping!"
+	- Increase reward for capping and reduce upgrade point income from other sources.

--- a/xeno/maturity.md
+++ b/xeno/maturity.md
@@ -25,7 +25,7 @@ What is required to progress on each castes varies as well.
 - General notes
 	- All castes gain a large bit of upgrade progress from capturing marines, This is to prevent them for not capping ever because
 	their task is to deal damage.
-	- All castes except Runners, Lurkers and Ravagers gain some max health when upgrading.
+	- All castes classes except Ambushers and Ranged gain some max health when upgrading.
 	- The amount of points for upgrading scales with the tier of the upgrade as well as the tier of the xenomorph, So acquiring
 	  a Primordial upgrade on a Crusher is much harder than it is on a defender.
 	- In addition to the tasks required to upgrade there is a time constraint: Xenomorphs start as Young in the beginning of the round
@@ -65,7 +65,7 @@ As a whole the "ranged" class gain reduced cooldowns and increased damage. More 
 deal acid damage when slashing in their latter upgrades.
 
 #### Tasks
-Spitters and Boilers gain upgrade points for dealing acid\burn damage while spitters gain points for stunning or knocking
+Spitters and Boilers gain upgrade points for dealing acid\burn damage while sentinels gain points for stunning or knocking
 down marines.
 
 
@@ -84,7 +84,7 @@ of points from these tasks.
 
 #### Upgrades & Tasks
 Praetorians are a bit of a wild card because of the wide array of roles they can take, Their upgrades depend on their strain:
-- Base and Warden: Same as ranged
+- Base and Warden: Same as ranged, Wardens also gain points for healing \ shielding \ rejuvenating *wounded* xenos.
 - Vanguard and Oppressor: Same as frontline
 - Dancer: Same as ambush
 


### PR DESCRIPTION
*This is just the general idea and is subject to change, all feedback is welcome*
## Abstract
Maturity is a system that allows Xenomorphs to become stronger over the course of the round. As the round progresses
Xenomorphs acquire new tiers they can "upgrade" into within their own caste, Each tier makes them either deal more damage,
more tanky or able to build faster all depending on the caste. These upgrades are not free however, Each and every Xeno has
to complete certain tasks depending on its caste in order to qualify for the upgrade, this is meant to reward players for playing
well.

## Goals
- Reward players for playing well
- Give xenomorphs a more scaling role
	- Prevent endless FOB sieges
	- Take away some of Boiler's strength
- Give more meaning and difference to pushing \ defending
	- Reward marines better for killing T3s or Primordial xenos as they can't be replaced as easily
- Lower xeno strength early
  - Xenos are very strong as of late with the removal of double shotguns etc. They're able to beat marines even in the first engagement which is *supposed* to be when Marines are at their strongest- This then develops into a FOB siege after 10 minutes of gameplay which is unfun- By shifting xeno strength into later in the round this will hopefully make xenos take a more defensive approach.
## Non-goals
- Encourage AFKing. These upgrades are not free and should not be achiveable by simply AFKing in hive.
- Make xenos too weak or too strong. Xenos should not be too weak while Young or unkillable while Primordial.
- Discourage capping. Castes that are tasked with slashing should not be discouraged from capping but rather rewarded for that as well.

## Content
Maturity introduces 5 tiers of upgrades: Young, Mature, Elder, Ancient and Primordial. What each tier gives varies based on the caste.
What is required to progress on each castes varies as well.

- General notes
	- All castes gain a large bit of upgrade progress from capturing marines, This is to prevent them for not capping ever because their task is to deal damage.
	- All castes classes except Ambushers and Ranged gain some max health when upgrading.
	- The amount of points for upgrading scales with the tier of the upgrade as well as the tier of the xenomorph, So acquiring
	  a Primordial upgrade on a Crusher is much harder than it is on a defender.
	- In addition to the tasks required to upgrade there is a time constraint: Xenomorphs start as Young in the beginning of the round
	and have the Mature tier unlocked. Then, After every 30 minutes a new tier is unlocked for xenos to upgrade into. (So at 1:30 round time
	xenos will have all tiers unlocked)
	- You may gain upgrade progress for the next tier even if it's not unlocked yet however you may not gain an "overflow" for the tier
	after that. (Similar to evolution)
	- You gain 0 upgrade points passively, The system is meant to reward you for playing well, not for AFKing in hive.

### Runners, Lurkers and Ravagers

#### Upgrades
"Ambush" or "Burst Damage" is the class of these castes, Therefore they get increased damage and speed. This is to make them better at
their job without taking away their weakness, that being a small health pool or temporary shields holding them together in the frontline.

#### Tasks
Simply enough and matching with their role Runners, Lurker and Ravagers have to deal damage in order to gain upgrades.


### Drones, Hivelords, Carriers and Burrowers

#### Upgrades
Builders and trappers, as they upgrade they gain increased plasma pools, increased plasma regeneration and increased armor
and slash damage in the case of burrowers as they take a more offensive role.

#### Tasks
Drones and Hivelords gain upgrade points for builindg walls and doors and when doors and walls they build are destroyed by
marines (Drones that cannot build gain points depending on their strain, Healer gains points for healing etc.)
Carriers and Burrowers gain points whenever they build traps and when the traps are triggered, Carrier gains more points
than other castes for capping.


### Sentinels, Spitters and Boilers

#### Upgrades
As a whole the "ranged" class gain reduced cooldowns and increased damage. More specifically Spitters and Boilers 
deal acid damage when slashing in their latter upgrades.

#### Tasks
Spitters and Boilers gain upgrade points for dealing acid\burn damage while sentinels gain points for stunning or knocking
down marines.


### Defenders, Warriors and Crushers

#### Upgrades
The frontline class gains well, Increased frontlining capabilities. This means a balance between health, armor and slash damage.

#### Tasks
As this is a more general role they can get upgrade points from almost anything: Tanking damage, Stunning \ Knocking down marines
or slashing and dleaing damage, However because of the plentiful ways for them to gain points they get a relatively reduced amount
of points from these tasks.


### Praetorians

#### Upgrades & Tasks
Praetorians are a bit of a wild card because of the wide array of roles they can take, Their upgrades depend on their strain:
- Base and Warden: Same as ranged, Wardens also gain points for healing \ shielding \ rejuvenating *wounded* xenos.
- Vanguard and Oppressor: Same as frontline
- Dancer: Same as ambush


### Queen

#### Upgrades & Tasks
The Queen is another wildcard, As they are a combination of pretty much every role they gain upgrade points from anything:
Slashing, Capping, Taking damage, Building, Healing, Transfering Plasma etc..
By the same logic they also gain increased all around stats with the exception of speed.
The Queen's upgrade point requirement is the largest of all xenos, This is both because the Queen is the strongests Xenomorph and to reward Marines
for taking her down.


### Abomination \ Predalien

#### Upgrades & Tasks
Abominations are not affected by the Maturity system as they already have a scaling mechanic related to kills.


## Alternatives
- Keep the game as is resulting in:
	- Endless FOB seiges
	- No satisfaction in killing T3s as a new one just evolves

## Potential Changes
- "Xenomorphs get too strong too quickly"
	- Make the amount of upgrade points required larger.
- "X caste is unkillable when Primordial"
	- Nerf its bonuses or switch them around.
- "X caste is way too weak early on"
	- Buff it at young and take some power from the later evolutions.
- "Frontline castes are just slashing everyone without capping!"
	- Increase reward for capping and reduce upgrade point income from other sources.
