### PR TITLE
 IOs and Objectives

### DIFF
--- a/IOs_and_Objectives.md
+++ b/IOs_and_Objectives.md
@@ -1,34 +1,41 @@
-##Abstract
-Made at the request of Fira.
+## Abstract
+   Made at the request of Fira.
 
-Intelligence Officers (IOs) are a role intended to provide marines with a unique playstyle, different from what is usually expected of squad roles. IOs are tasked with scouring the colony in search of documents and simillar items to receive "tech points", which can then be cashed in for goodies to help the other marines.
+  Intelligence Officers (IOs) are a role intended to provide marines with a unique playstyle, different from what is usually expected of squad roles. IOs are tasked with scouring the colony in search of documents and simillar items to receive "tech points", which can then be cashed in for goodies to help the other marines.
 
-Additionally other tasks, such as setting up comms or power and retrieving corpses will also award tech points, encouraging marines to pursue other tasks such as setting power or utilising the fulton for retrieving corpses.
+  Additionally other tasks, such as setting up comms or power and retrieving corpses will also award tech points, encouraging marines to pursue other tasks such as setting power or utilising the fulton for retrieving corpses.
+## Goals
+- Provide marines with a unique playstyle different from the usual unga
+- Encourage marines to disperse across the map rather than conglomerate on a deathball
+- Encourage inter-departmental cooperation (IOs-Marines, Marines-PO, IO-PO)
 
-##Goals
-Provide marines with a unique playstyle different from the usual unga
-Encourage marines to disperse across the map rather than conglomerate on a deathball
-Encourage inter-department cooperation (IOs-Marines, Marines-PO, IO-PO)
-##Non-goals
-Bring IOs to the forefront of marine strategy. IOs should be a nice boon, not mandatory.
-Encourage cadehugging. Hiding behind cades while IOs try to earn more points shouldn't be a viable strategy.
-Give IOs OP gear/skills. IOs shouldn't be desirable to people because of their skills/equipment.
-Content
-IOs will function simmilarly to how they did in the past, with their main goal being to roam the colony in search of intel.
+## Non-goals
+- Bring IOs to the forefront of marine strategy. IOs should be a nice boon, not mandatory.
+- Encourage cadehugging. Hiding behind cades while IOs try to earn more points shouldn't be a viable strategy.
+- Give IOs OP gear/skills. IOs shouldn't be desirable to people because of their skills/equipment.
+
+## Content
+  IOs will function simmilarly to how they did in the past, with their main goal being to roam the colony in search of intel.
 The main difference from how they functioned in the past will be the much MUCH lower impact of them on a given round, rather than game ending nukes IOs now will only be able to acquire extra req/CAS points or OBs for their team. The aim is to make IOs not completely uselesses but to also not have them be mandatory like in the old days of DEFCON.
 
-##Alternatives
-Doing away with the concept of IOs and simply dissemenating their tools to the general marine population, this may encourage command to assign squads to specific taks other than "scout" like retrieve intel, set power or collect corpses.
+##Data Decryption
+  When an IO finds a piece of intel they will require to read it, this will take a few seconds and, once finished, will give the IO a clue to one or more objectives, the objective hierarchy goes paper scrap>folder>disk. Disks can only be decrypted shipside and will require a password from a folder. There are also other kinds of documents that are separate from the main hierarchy such as progress reports and technical manuals, these take much longer read and rarely lead to other documents but give out extra points.
+  Once an IO has acquired enough intel they must return shipside and upload to the central intelligence database using the computer located in their office, which will award them with "tech points"
 
-Additionally, making IOs a squad role, this will either result in command merging all squad IOs into a single squad, thus invalidating the squad part entirely,
-IOs running off either alone or in a mini squad, also invalidates the point of making it a squad role, IOs stay in their squad and do a subpar job due to not being able to go to all areas of the map.
+##IOs and Objectives
+  Despite being able to be fulfilled by anyone IOs are expected to be the main driving force tech point gathering and shouldn't simply relegate themselves to intel gathering, IOs are expected to fulton corpses (xeno or human) and to encourage their fellow marines to do the same, it may take awhile but eventually marines will engage with the objectives voluntarily without the need for IOs to encourage them.
 
-Also, if the objective angle is found to be undesirable making documents the only way of earning "tech points" is also an option.
+## Alternatives
+  Doing away with the concept of IOs and simply dissemenating their tools to the general marine population, this may encourage command to assign squads to specific taks other than "scout" like retrieve intel, set power or collect corpses.
 
-##Potential Changes
-"IOs earn points too slowly"
-Increase the reward for completing tasks.
-"There's no incentive to hold engineering after setting power"
-Make it so power and communications award a constant stream of points rather than being one and done.
-"No one wants to process intel"
-Create a role simillar to DCC but for IOs, possibly an SO of sorts to help with coordination.
+  Additionally, making IOs a squad role, this will either result in command merging all squad IOs into a single squad, thus invalidating the squad part entirely,
+IOs running off either alone or in a mini squad, also invalidates the point of making it a squad role,  IOs stay in their squad and do a subpar job due to not being able to go to all areas of the map.
+
+  Also, if the objective angle is found to be undesirable making documents the only way of earning "tech points" is also an option.
+## Potential Changes
+- "IOs earn points too slowly"
+	- Increase the reward for completing tasks.
+- "There's no incentive to hold engineering after setting power"
+	- Make it so power and communications award a constant stream of points rather than being one and done.
+- "No one wants to process intel"
+	- Create a role simillar to DCC but for IOs, possibly an SO of sorts to help with coordination.


### PR DESCRIPTION
## Abstract
   Made at the request of Fira.

  Intelligence Officers (IOs) are a role intended to provide marines with a unique playstyle, different from what is usually expected of squad roles. IOs are tasked with scouring the colony in search of documents and simillar items to receive "tech points", which can then be cashed in for goodies to help the other marines.

  Additionally other tasks, such as setting up comms or power and retrieving corpses will also award tech points, encouraging marines to pursue other tasks such as setting power or utilising the fulton for retrieving corpses.
## Goals
- Provide marines with a unique playstyle different from the usual unga
- Encourage marines to disperse across the map rather than conglomerate on a deathball
- Encourage inter-departmental cooperation (IOs-Marines, Marines-PO, IO-PO)

## Non-goals
- Bring IOs to the forefront of marine strategy. IOs should be a nice boon, not mandatory.
- Encourage cadehugging. Hiding behind cades while IOs try to earn more points shouldn't be a viable strategy.
- Give IOs OP gear/skills. IOs shouldn't be desirable to people because of their skills/equipment.

## Content
  IOs will function simmilarly to how they did in the past, with their main goal being to roam the colony in search of intel.
The main difference from how they functioned in the past will be the much MUCH lower impact of them on a given round, rather than game ending nukes IOs now will only be able to acquire extra req/CAS points or OBs for their team. The aim is to make IOs not completely uselesses but to also not have them be mandatory like in the old days of DEFCON.

##Data Decryption
  When an IO finds a piece of intel they will require to read it, this will take a few seconds and, once finished, will give the IO a clue to one or more objectives, the objective hierarchy goes paper scrap>folder>disk. Disks can only be decrypted shipside and will require a password from a folder. There are also other kinds of documents that are separate from the main hierarchy such as progress reports and technical manuals, these take much longer read and rarely lead to other documents but give out extra points.
  Once an IO has acquired enough intel they must return shipside and upload to the central intelligence database using the computer located in their office, which will award them with "tech points"

##IOs and Objectives
  Despite being able to be fulfilled by anyone IOs are expected to be the main driving force tech point gathering and shouldn't simply relegate themselves to intel gathering, IOs are expected to fulton corpses (xeno or human) and to encourage their fellow marines to do the same, it may take awhile but eventually marines will engage with the objectives voluntarily without the need for IOs to encourage them.

## Alternatives
  Doing away with the concept of IOs and simply dissemenating their tools to the general marine population, this may encourage command to assign squads to specific taks other than "scout" like retrieve intel, set power or collect corpses.

  Additionally, making IOs a squad role, this will either result in command merging all squad IOs into a single squad, thus invalidating the squad part entirely,
IOs running off either alone or in a mini squad, also invalidates the point of making it a squad role,  IOs stay in their squad and do a subpar job due to not being able to go to all areas of the map.

  Also, if the objective angle is found to be undesirable making documents the only way of earning "tech points" is also an option.
## Potential Changes
- "IOs earn points too slowly"
	- Increase the reward for completing tasks.
- "There's no incentive to hold engineering after setting power"
	- Make it so power and communications award a constant stream of points rather than being one and done.
- "No one wants to process intel"
	- Create a role simillar to DCC but for IOs, possibly an SO of sorts to help with coordination.