### PR TITLE
added design file for toxic sentinel strain

### DIFF
--- a/xeno/Toxic-Sentinel.md
+++ b/xeno/Toxic-Sentinel.md
@@ -1,0 +1,44 @@
+
+## Abstract
+
+Add a new Strain to expand upon the scope of xeno power without just giving them just larger damage numbers.
+The Toxic Sentinel strain extends the power of the xenos without inducing power creep, by only offering it to a T1 xeno.
+Introducing toxic damage to the core loop should expand the role of medics and ideally create an indirect counter to the multitude of marines
+that fill up on bicardine, kelotane, and inaprovalin autoinjectors.
+
+## Goals
+
+1) This feature should introduce a new damage source while also diversifying the T1 combat castes.
+2) Create a different play style to the typical Sentinel playstyle of stun -> slash -> run.
+3) While individually a single Toxic Sentinel is not as threatening as the base Sentinel, it should be more feared in groups where it is not the only source of toxic damage.
+
+
+## Non-goals
+
+Do not just give the xeno a passive toxic bonus nor make it too high, there is no need for every marine to start bringing dylovene as a 4th autoinjector.
+Do not make a more powerful sentinel, this strain should bring with it trade offs that provide a different playstyle to the base Sentinel.
+It will not have any armor. This is not just a melee spitter, it still is the unarmored main force support that sentinel is.
+
+## Content
+
+New strain Toxic Sentinel
+This Sentinel Strain focuses on joining on the mainline offense, with toxic damage buildup, a blind, and a movement stim.
+As a frontliner with no armor, it should get some more health to compensate.
+
+Blinding Spit acts as a short range ability to make it safer to attack the frontline, 
+it only lasts a short ammount of time, should be no longer than 3 seconds, with a minimum cooldown of 3 seconds, and a minimum plasma cost of 40 plasma.
+
+Sprint acts a way to be more active on the frontline since you have no garunteed way to stun enemies.
+It should last no longer than 40 seconds, with a minimum cooldown of 60 seconds, and a minimum cost of 40 plasma.
+
+Toxic slash is a toggleable ability that makes the Sentinel deal toxic damage with every slash. I have literally no idea how much damage it should be,
+but the plasma cost needs to be significant and it should be the main for of dealing damage.
+
+## Alternatives
+
+I truly cannot think of any alternatives at the moment.
+
+## Potential Changes
+
+More than likely the toxic damage will have to be adjusted. The toggle toxic slash ability could also provide an attack speed buff at the cost of even more plasma.
+It may need more health and plasma to compensate for its more dangerous playstyle.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## Abstract

Add a new Strain to expand upon the scope of xeno power without just giving them just larger damage numbers.
The Toxic Sentinel strain extends the power of the xenos without inducing power creep, by only offering it to a T1 xeno.
Introducing toxic damage to the core loop should expand the role of medics and ideally create an indirect counter to the multitude of marines
that fill up on bicardine, kelotane, and inaprovalin autoinjectors.

## Goals

1) This feature should introduce a new damage source while also diversifying the T1 combat castes.
2) Create a different play style to the typical Sentinel playstyle of stun -> slash -> run.
3) While individually a single Toxic Sentinel is not as threatening as the base Sentinel, it should be more feared in groups where it is not the only source of toxic damage.


## Non-goals

Do not just give the xeno a passive toxic bonus nor make it too high, there is no need for every marine to start bringing dylovene as a 4th autoinjector.
Do not make a more powerful sentinel, this strain should bring with it trade offs that provide a different playstyle to the base Sentinel.
It will not have any armor. This is not just a melee spitter, it still is the unarmored main force support that sentinel is.

## Content

New strain Toxic Sentinel
This Sentinel Strain focuses on joining on the mainline offense, with toxic damage buildup, a blind, and a movement stim.
As a frontliner with no armor, it should get some more health to compensate.

Blinding Spit acts as a short range ability to make it safer to attack the frontline, 
it only lasts a short ammount of time, should be no longer than 3 seconds, with a minimum cooldown of 3 seconds, and a minimum plasma cost of 40 plasma.

Sprint acts a way to be more active on the frontline since you have no garunteed way to stun enemies.
It should last no longer than 40 seconds, with a minimum cooldown of 60 seconds, and a minimum cost of 40 plasma.

Toxic slash is a toggleable ability that makes the Sentinel deal toxic damage with every slash. I have literally no idea how much damage it should be,
but the plasma cost needs to be significant and it should be the main for of dealing damage.

## Alternatives

I truly cannot think of any alternatives at the moment.

## Potential Changes

More than likely the toxic damage will have to be adjusted. The toggle toxic slash ability could also provide an attack speed buff at the cost of even more plasma.
It may need more health and plasma to compensate for its more dangerous playstyle.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

